### PR TITLE
Update Dependencies to Match Riak 1.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps,
  [
   %% ibrowse for doing HTTP requests
-  {ibrowse, ".*", {git, "git://github.com/dizzyd/ibrowse.git", 
+  {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", 
                    {branch, "master"}}},
 
    %% mochiweb for JSON and header parsing


### PR DESCRIPTION
Picking up changes in riakc, webmachine, and mochiweb.

Also switching ibrowse dep to upstream, instead of dizzy's branch, now that it's rebar-compatible.
