### PR TITLE
set erl_opts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{erl_opts, []}.
+
 {deps,
  [
   %% ibrowse for doing HTTP requests


### PR DESCRIPTION
rebar dependencies inherit options from the parent. In my projects, I have warn_missing_specs and warnings_as_errors, which causes riakhttpc to fail to compile.

This sets the options to an empty list which fixes the problem.
