### PR TITLE
Updating the version of number of the riak-client dependency to 1.2.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,6 @@
                           {tag, "1.9.0"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, "1.2.0", {git, "git://github.com/basho/riak-erlang-client",
+   {riakc, "1.2.1", {git, "git://github.com/basho/riak-erlang-client",
                      {branch, "master"}}}
   ]}.


### PR DESCRIPTION
The version number of the riak client has been updated, which causes this driver to fail to build because of a version_mismatch error.  

This change is needed in order to allow clients to install using a freshly cloned repo.
