### PR TITLE
Add ability to modify postcommit hooks on a bucket

### DIFF
--- a/include/raw_http.hrl
+++ b/include/raw_http.hrl
@@ -47,6 +47,7 @@
 -define(JSON_ALLOW_MULT, <<"allow_mult">>).
 -define(JSON_N_VAL,    <<"n_val">>).
 -define(JSON_PRECOMMIT, <<"precommit">>).
+-define(JSON_POSTCOMMIT, <<"postcommit">>).
 
 
 %% Names of HTTP query parameters

--- a/src/rhc_bucket.erl
+++ b/src/rhc_bucket.erl
@@ -34,6 +34,7 @@ erlify_props(Props) ->
 erlify_prop(?JSON_N_VAL, N) -> {n_val, N};
 erlify_prop(?JSON_ALLOW_MULT, AM) -> {allow_mult, AM};
 erlify_prop(?JSON_PRECOMMIT, P) -> {precommit, P};
+erlify_prop(?JSON_POSTCOMMIT, P) -> {postcommit, P};
 erlify_prop(_Ignore, _) -> [].
 
 httpify_props(Props) ->
@@ -41,4 +42,5 @@ httpify_props(Props) ->
 httpify_prop(n_val, N) -> {?JSON_N_VAL, N};
 httpify_prop(allow_mult, AM) -> {?JSON_ALLOW_MULT, AM};
 httpify_prop(precommit, P) -> {?JSON_PRECOMMIT, P};
+httpify_prop(postcommit, P) -> {?JSON_POSTCOMMIT, P};
 httpify_prop(_Ignore, _) -> [].


### PR DESCRIPTION
Just like the precommit ability already included, this allows the modification of postcommit hooks on a bucket.  Configured hooks will appear in a `postcommit` property in the list returned from `rhc:get_bucket/2`, and they may be set by including a `postcommit` property in `rhc:set_bucket/3`.

If this PR is accepted, @rzezeski's PR #6 to add the `search` bucket property should probably also be accepted.
