### PR TITLE
bumped riakc version to 1.3.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,6 @@
                           {tag, "1.9.0"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, "1.3.0", {git, "git://github.com/basho/riak-erlang-client",
-                     {tag, "1.3.0"}}}
+   {riakc, "1.3.1", {git, "git://github.com/basho/riak-erlang-client",
+                     {tag, "1.3.1"}}}
   ]}.


### PR DESCRIPTION
This is to fix an issue with riakc:get_index/\* found w/ riak_test.
