### PR TITLE
Advance dep on riakc and use glob match to be liberal in what version to...

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,6 @@
                           {tag, "1.9.0"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, "1.3.1", {git, "git://github.com/basho/riak-erlang-client",
-                     {tag, "1.3.1"}}}
+   {riakc, "1.3.*", {git, "git://github.com/basho/riak-erlang-client",
+                     {tag, "1.3.3"}}}
   ]}.


### PR DESCRIPTION
... accept

At the moment, a "master" branch build of riak_test is failing when starting from scratch.

```
Cloning into 'webmachine'...
ERROR: Dependency dir /Users/fritchie/b/src/riak_test/deps/riakc failed application validation with reason:
{version_mismatch,{"/Users/fritchie/b/src/riak_test/deps/riakc/ebin/riakc.app",
                   {expected,"1.3.1"},
                   {has,"1.3.3"}}}.
```
