### PR TITLE
Add 2i term regex filter

### DIFF
--- a/include/raw_http.hrl
+++ b/include/raw_http.hrl
@@ -109,3 +109,4 @@
 -define(Q_PAGINATION_SORT, "pagination_sort").
 -define(Q_MAXRESULTS, "max_results").
 -define(Q_CONTINUATION, "continuation").
+-define(Q_TERM_REGEX, "term_regex").

--- a/src/rhc_index.erl
+++ b/src/rhc_index.erl
@@ -48,6 +48,10 @@ query_option({continuation, C}) when is_binary(C) ->
     [{?Q_CONTINUATION, binary_to_list(C)}];
 query_option({continuation, C}) when is_list(C) ->
     [{?Q_CONTINUATION, C}];
+query_option({term_regex, C}) when is_binary(C) ->
+    [{?Q_TERM_REGEX, binary_to_list(C)}];
+query_option({term_regex, C}) when is_list(C) ->
+    [{?Q_TERM_REGEX, C}];
 query_option({return_terms, B}) when is_boolean(B) ->
     [{?Q_RETURNTERMS, atom_to_list(B)}];
 query_option({pagination_sort, B}) when is_boolean(B) ->


### PR DESCRIPTION
@russelldb This will be needed to exercise the 1.4 version of secondary_index_tests after merging the changes for the 2i sort and term regex features.
