### PR TITLE
Adds URL-escaping to buckets, bucket types and keys 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ deps:
 clean:
 	@./rebar clean
 
+test: all
+		@./rebar skip_deps=true eunit
+
 distclean: clean
 	@./rebar delete-deps
 


### PR DESCRIPTION
URL-escapes buckets, bucket types and keys in methods that generate URLs. Adds (the first) unit test and an appropriate <code>Makefile</code> target.

I didn't sweat the 80 character-per-line rule because it's broken often in this file.