### PR TITLE
Remove Erlang versions prior to 15B01 from the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=a67b2dff7f7a090440d34f35de60d0a8fd66b696
   email: eng@basho.com
 otp_release:
+  - R16B02
+  - R16B01
+  - R15B03
+  - R15B02
   - R15B01
-  - R15B
-  - R14B04
-  - R14B03


### PR DESCRIPTION
. We can't use Erlang OTP releases before 15B01 anymore because the riakc dependency uses <code>-callback</code> attributes.
