### PR TITLE
Updated README.org requirement for Erlang OTP version >= R15B01

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@
 interface
 
 ** Quick Start
-   You must have [[http://erlang.org/download.html][Erlang/OTP R13B04]] or later and a GNU-style build
+   You must have [[http://erlang.org/download.html][Erlang/OTP R15B01]] or later and a GNU-style build
    system to compile and run =riak-erlang-http-client=.
 
 #+BEGIN_SRC shell


### PR DESCRIPTION
README now reflects the correct OTP Release required to build. 
