### PR TITLE
remove unicode:characters_to_list/1 conversions

### DIFF
--- a/src/rhc.erl
+++ b/src/rhc.erl
@@ -684,7 +684,7 @@ update_type(Rhc, BucketAndType, Key, {Type, Op, Context}, Options) ->
         {ok, "201", Headers, RBody} ->
             %% Riak-assigned key
             Url = proplists:get_value("Location", Headers),
-            Key = list_to_binary(lists:last(string:tokens(Url, "/"))),
+            Key = unicode:characters_to_binary(lists:last(string:tokens(Url, "/")), utf8),
             case proplists:get_value("Content-Length", Headers) of
                 "0" ->
                     {ok, Key};
@@ -770,7 +770,7 @@ index_url(Rhc, BucketAndType, Index, Query, Params) ->
     {Type, Bucket} = extract_bucket_type(BucketAndType),
     QuerySegments = index_query_segments(Query),
     IndexName = index_name(Index),
-    unicode:characters_to_list(
+    lists:flatten(
       [root_url(Rhc),
        [ ["types", "/", Type, "/"] || Type =/= undefined ],
        "buckets", "/", Bucket, "/", "index", "/", IndexName,
@@ -803,7 +803,7 @@ index_name(Idx) -> Idx.
 make_url(Rhc=#rhc{}, BucketAndType, Key, Query) ->
     {Type, Bucket} = extract_bucket_type(BucketAndType),
     {IsKeys, IsProps, IsBuckets} = detect_bucket_flags(Query),
-    unicode:characters_to_list(
+    lists:flatten(
         [root_url(Rhc),
          [ [ "types", "/", Type, "/"] || Type =/= undefined ],
          %% Prefix, "/",
@@ -818,18 +818,17 @@ make_url(Rhc=#rhc{}, BucketAndType, Key, Query) ->
 %% @doc Generate a counter url.
 -spec make_counter_url(rhc(), term(), term(), list()) -> iolist().
 make_counter_url(Rhc, Bucket, Key, Query) ->
-    binary_to_list(
-      iolist_to_binary(
+    lists:flatten(
         [root_url(Rhc),
          <<"buckets">>, "/", Bucket, "/", <<"counters">>, "/", Key, "?",
-         [ [mochiweb_util:urlencode(Query)] || Query =/= []]])).
+         [ [mochiweb_util:urlencode(Query)] || Query =/= []]]).
 
 make_datatype_url(Rhc, BucketAndType, Key, Query) ->
     case extract_bucket_type(BucketAndType) of
         {undefined, _B} ->
             throw(default_bucket_type_disallowed);
         {Type, Bucket} ->
-            unicode:characters_to_list(
+            lists:flatten(
               [root_url(Rhc),
                "types/", Type,
                "/buckets/", Bucket,

--- a/src/rhc_listkeys.erl
+++ b/src/rhc_listkeys.erl
@@ -46,11 +46,11 @@ wait_for_list(ReqId, Timeout) ->
 %% @private
 wait_for_list(ReqId, _Timeout0, Acc) ->
     receive
-        {ReqId, done} -> 
+        {ReqId, done} ->
             {ok, lists:flatten(Acc)};
-        {ReqId, {error, Reason}} -> 
+        {ReqId, {error, Reason}} ->
             {error, Reason};
-        {ReqId, {_,Res}} -> 
+        {ReqId, {_,Res}} ->
             wait_for_list(ReqId,_Timeout0,[Res|Acc])
     end.
 
@@ -107,20 +107,20 @@ is_empty(#parse_state{}) ->
     false.
 
 try_parse(Data, #parse_state{buffer=B, brace=D, quote=Q, escape=E}) ->
-    Parse = try_parse(binary_to_list(Data), B, D, Q, E),
+    Parse = try_parse(unicode:characters_to_list(Data, utf8), B, D, Q, E),
     {KeyLists, NewParseState} =
         lists:foldl(
           fun(Chunk, Acc) when is_list(Chunk), is_list(Acc) ->
                   {struct, Props} =  mochijson2:decode(Chunk),
-                  Keys = 
+                  Keys =
                       case proplists:get_value(<<"keys">>, Props, []) of
-                          [] -> 
-                              proplists:get_value(<<"buckets">>, 
+                          [] ->
+                              proplists:get_value(<<"buckets">>,
                                                   Props, []);
                           K -> K
                       end,
                   case Keys of
-                      [] -> 
+                      [] ->
                           %%check for a timeout error
                           case proplists:get_value(<<"error">>, Props, []) of
                               [] -> Acc;


### PR DESCRIPTION
Calls to unicode:characters_to_list/1 in functions such as rhc:make_url/4
prevent callers from passing in any unicode binaries already converted to
UTF-8, since unicode:characters_to_list/1 converts the data back to full
unicode values. Since these values can exceed the range of a byte, trying
to send them over a socket as part of an HTTP request fails with einval.

These changes allow UTF-8 binaries passed from the caller to work
correctly.
