### PR TITLE
Bump riakc dep to 3038f3bcc23dd3b759c0f1124dab6ab4b8f3a9e0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {deps,
  [
   %% ibrowse for doing HTTP requests
-  {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", 
+  {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git",
                    "bbad869ea595c594912cf71fbd622aa80577c8f6"}},
 
    %% webmachine for multipart content parsing, will pull in mochiweb as a dep
@@ -12,7 +12,7 @@
 
    %% riak-erlang-client for riakc_obj
    {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client",
-                     "15f5761bd2b27cd6375e8db8f7ffae036b2bbdc3"}}
+                     "3038f3bcc23dd3b759c0f1124dab6ab4b8f3a9e0"}}
   ]}.
 {edoc_opts,
  [


### PR DESCRIPTION
Bump riakc dependency to 3038f3bcc23dd3b759c0f1124dab6ab4b8f3a9e0
in order to pull in the 2.0.0.16 tag of riak_pb.
