### PR TITLE
Add RangeReg as a new supported datatype

### DIFF
--- a/src/rhc_dt.erl
+++ b/src/rhc_dt.erl
@@ -46,7 +46,15 @@ decode_value(map, {struct, Fields}) ->
     [ begin
           {Name, Type} = field_from_json(Field),
           {{Name,Type}, decode_value(Type, Value)}
-      end || {Field, Value} <- Fields ].
+      end || {Field, Value} <- Fields ];
+decode_value(rangereg, {struct, Fields}) ->
+    [
+     begin
+         Field = atom_to_binary(F,utf8),
+         {F, proplists:get_value(Field, Fields, undefined)}
+     end || F <- [max, min, first, last]
+    ].
+
 
 field_from_json(Bin) when is_binary(Bin) ->
     {match, [Name, BinType]} = re:run(Bin, ?FIELD_PATTERN, [anchored, {capture, all_but_first, binary}]),
@@ -77,6 +85,8 @@ decode_error(_, {ok, _, _, Body}) ->
 
 encode_update_request(register, {assign, Bin}, _Context) ->
     {struct, [{<<"assign">>, Bin}]};
+encode_update_request(rangereg, {assign, Int}, _Context) ->
+    {struct, [{<<"assign">>, Int}]};
 encode_update_request(flag, Atom, _Context) ->
     atom_to_binary(Atom, utf8);
 encode_update_request(counter, Op, _Context) ->

--- a/src/rhc_dt.erl
+++ b/src/rhc_dt.erl
@@ -29,7 +29,7 @@
          decode_error/2
         ]).
 
--define(FIELD_PATTERN, "^(.*)_(counter|set|register|flag|map)$").
+-define(FIELD_PATTERN, "^(.*)_(counter|set|register|flag|map|range)$").
 
 datatype_from_json({struct, Props}) ->
     Value = proplists:get_value(<<"value">>, Props),
@@ -47,7 +47,7 @@ decode_value(map, {struct, Fields}) ->
           {Name, Type} = field_from_json(Field),
           {{Name,Type}, decode_value(Type, Value)}
       end || {Field, Value} <- Fields ];
-decode_value(rangereg, {struct, Fields}) ->
+decode_value(range, {struct, Fields}) ->
     [
      begin
          Field = atom_to_binary(F,utf8),
@@ -85,8 +85,8 @@ decode_error(_, {ok, _, _, Body}) ->
 
 encode_update_request(register, {assign, Bin}, _Context) ->
     {struct, [{<<"assign">>, Bin}]};
-encode_update_request(rangereg, {assign, Int}, _Context) ->
-    {struct, [{<<"assign">>, Int}]};
+encode_update_request(range, {add, Int}, _Context) ->
+    {struct, [{<<"add">>, Int}]};
 encode_update_request(flag, Atom, _Context) ->
     atom_to_binary(Atom, utf8);
 encode_update_request(counter, Op, _Context) ->


### PR DESCRIPTION
Rangereg is a register for integers that tracks the largest,
the smallest, the first (by timestamp) and the last (by timestamp)
integers assigned into it.

This allows you to assign new integers to the rangereg
(however, without specifying the timestamp).

This is part of the changes in basho/riak_kv#1005 .
