### PR TITLE
Bump webmachine dependency from 1.10.3 to 1.10.6

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,8 @@
                    "bbad869ea595c594912cf71fbd622aa80577c8f6"}},
 
    %% webmachine for multipart content parsing, will pull in mochiweb as a dep
-   {webmachine, "1.10.3", {git, "git://github.com/basho/webmachine",
-                          {tag, "1.10.3"}}},
+   {webmachine, "1.10.6", {git, "git://github.com/basho/webmachine",
+                          {tag, "1.10.6"}}},
 
    %% riak-erlang-client for riakc_obj
    {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client",


### PR DESCRIPTION
This doesn't change much except allow the client to easily be built with Erlang 17.