### PR TITLE
Update the webmachine dependency to 1.10.7 per @kellymclaughlin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,8 @@
                    "bbad869ea595c594912cf71fbd622aa80577c8f6"}},
 
    %% webmachine for multipart content parsing, will pull in mochiweb as a dep
-   {webmachine, "1.10.6", {git, "git://github.com/basho/webmachine",
-                          {tag, "1.10.6"}}},
+   {webmachine, "1.10.7", {git, "git://github.com/basho/webmachine",
+                          {tag, "1.10.7"}}},
 
    %% riak-erlang-client for riakc_obj
    {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client",


### PR DESCRIPTION
When Kelly updated riak_test to support Erlang 17 it broke some dependencies.  First here in the Erlang HTTP client and in webmachine.  Now that webmachine's version has been bumped, update it here as well.