### PR TITLE
add get_preflist to http-client

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,16 +3,14 @@
 {deps,
  [
   %% ibrowse for doing HTTP requests
-  {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git",
-                   "bbad869ea595c594912cf71fbd622aa80577c8f6"}},
+  {ibrowse, "4.0.2", 
+	{git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
 
    %% webmachine for multipart content parsing, will pull in mochiweb as a dep
-   {webmachine, "1.10.7", {git, "git://github.com/basho/webmachine",
-                          {tag, "1.10.7"}}},
+   {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client",
-                     "3038f3bcc23dd3b759c0f1124dab6ab4b8f3a9e0"}}
+   {riakc, "2.1.0", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.0"}}}
   ]}.
 {edoc_opts,
  [


### PR DESCRIPTION
### Description

Part of [RIAK-1481](https://bashoeng.atlassian.net/browse/RIAK-1481).

The active preflist will return primary/fallback partitions and nodes for the available nodes at the time of query. Primary/fallback will be annotated.
This involves updates to our RiakKV WB code, RiakPB, Riak-Erlang-Http-Client, Riak-Erlang-Client.

*The impetus for adding this to the API started with a mailing list question answered by Charlie Voiselle, http://lists.basho.com/pipermail/riak-users_lists.basho.com/2015-January/016527.html, which involved a snippet of code that we've given clients multiple times. This was then discussed with Russell Brown on HipChat, https://basho.hipchat.com/history/room/867200/2015/01/13?q=enterprising&t=rid-867200#12:23:22.

Other PRs in the series:

- https://github.com/basho/riak_pb/pull/105
- https://github.com/basho/riak_kv/pull/1083
- https://github.com/basho/riak-erlang-client/pull/204