### PR TITLE
update riak-erlang-http-client to handle hll datatypes and precision …

### DIFF
--- a/include/raw_http.hrl
+++ b/include/raw_http.hrl
@@ -93,6 +93,9 @@
 -define(JSON_RESULTS,      <<"results">>).
 -define(JSON_CONTINUATION, <<"continuation">>).
 
+%% dt related-fields
+-define(JSON_HLL_PRECISION, <<"hll_precision">>).
+
 %%======================================================================
 %% Names of HTTP query parameters
 %%======================================================================

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "feature-zl-hll_datatypes"}}}
+   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}}
   ]}.
 {edoc_opts,
  [

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}}
+   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "feature-zl-hll_datatypes"}}}
   ]}.
 {edoc_opts,
  [

--- a/src/rhc_bucket.erl
+++ b/src/rhc_bucket.erl
@@ -53,6 +53,7 @@ erlify_prop(?JSON_SEARCH, B) -> {search, B};
 erlify_prop(?JSON_SMALL_VC, I) -> {small_vclock, I};
 erlify_prop(?JSON_W, W) -> {w, erlify_quorum(W)};
 erlify_prop(?JSON_YOUNG_VC, I) -> {young_vclock, I};
+erlify_prop(?JSON_HLL_PRECISION, P) -> {hll_precision, P};
 erlify_prop(_Ignore, _) -> [].
 
 erlify_quorum(?JSON_ALL) -> all;
@@ -105,6 +106,7 @@ httpify_prop(search, B) -> {?JSON_SEARCH, B};
 httpify_prop(small_vclock, VC) -> {?JSON_SMALL_VC, VC};
 httpify_prop(w, Q) -> {?JSON_W, Q};
 httpify_prop(young_vclock, VC) -> {?JSON_YOUNG_VC, VC};
+httpify_prop(hll_precision, P) -> {?JSON_HLL_PRECISION, P};
 httpify_prop(_Ignore, _) -> [].
 
 httpify_modfun({modfun, M, F}) ->

--- a/src/rhc_dt.erl
+++ b/src/rhc_dt.erl
@@ -29,7 +29,7 @@
          decode_error/2
         ]).
 
--define(FIELD_PATTERN, "^(.*)_(counter|set|register|flag|map)$").
+-define(FIELD_PATTERN, "^(.*)_(counter|set|hll|register|flag|map)$").
 
 datatype_from_json({struct, Props}) ->
     Value = proplists:get_value(<<"value">>, Props),
@@ -40,6 +40,7 @@ datatype_from_json({struct, Props}) ->
 
 decode_value(counter, Value) -> Value;
 decode_value(set, Value) -> Value;
+decode_value(hll, Value) -> Value;
 decode_value(flag, Value) -> Value;
 decode_value(register, Value) -> Value;
 decode_value(map, {struct, Fields}) ->
@@ -85,8 +86,12 @@ encode_update_request(set, {update, Ops}, Context) ->
     {struct, Ops ++ include_context(Context)};
 encode_update_request(set, Op, Context) ->
     {struct, [Op|include_context(Context)]};
+encode_update_request(hll, {update, Ops}, Context) ->
+    {struct, Ops ++ include_context(Context)};
+encode_update_request(hll, Op, Context) ->
+    {struct, [Op|include_context(Context)]};
 encode_update_request(map, {update, Ops}, Context) ->
-    {struct, orddict:to_list(lists:foldl(fun encode_map_op/2, orddict:new(), Ops)) ++ 
+    {struct, orddict:to_list(lists:foldl(fun encode_map_op/2, orddict:new(), Ops)) ++
              include_context(Context)}.
 
 encode_map_op({add, Entry}, Ops) ->


### PR DESCRIPTION
…settings, rebar placeholder until we update riakc version

- Update Http client for HLL(set) datatypes
- Will need a correct version for the riak-erlang-client ~ https://github.com/basho/riak-erlang-http-client/pull/56/files#diff-31d7a50c99c265ca2793c20961b60979R13