### PR TITLE
Change TS dep to master for riak-erlang-client

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "riak_ts-develop"}}}
+   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}}
   ]}.
 {edoc_opts,
  [


### PR DESCRIPTION
Since the Erlang PB client was merged with TS update the dep