### PR TITLE
Revert riak-erlang-client to master for testing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
    {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
 
    %% riak-erlang-client for riakc_obj
-   {riakc, "2.1.2", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.2"}}}
+   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}}
   ]}.
 {edoc_opts,
  [


### PR DESCRIPTION
Since this is pinned to a particular tag on `master` that means the `riak-erlang-client` cannot easily be tested from `master`