### PR TITLE
Mas i1847 conditionalput (#86)

### DIFF
--- a/include/raw_http.hrl
+++ b/include/raw_http.hrl
@@ -38,6 +38,7 @@
 -define(HEAD_CLIENT,          "X-Riak-ClientId").
 -define(HEAD_USERMETA_PREFIX, "x-riak-meta-").
 -define(HEAD_INDEX_PREFIX,    "X-Riak-Index-").
+-define(HEAD_IF_NOT_MODIFIED, "X-Riak-If-Not-Modified").
 
 %%======================================================================
 %% JSON keys/values


### PR DESCRIPTION
Add support for `if_not_modified` option, which should work as with riak-erlang-client (and use the X-Riak-If-Not-Modified) header in Riak 3.0.13.

Add support for using `if_none_match`, and `if_match`.  However, if possible, `if_not_modified` should always in preference to `if_match` as `if_match` requires re-calculation of the etag, using knowledge that should be internal to Riak.